### PR TITLE
Docs [README] Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The CSR Generator is a Go package that provides functionality for generating Cer
 
 - [x] Private CAs that rely on domain and DNS names (e.g, [`Google Cloud Private CAs`](https://cloud.google.com/security/products/certificate-authority-service))
 > [!NOTE]
-> `Private CAs that rely on domain and DNS names` can be used for `Enterprise/DevOps/DevSecOps` purposes.
+> `Private CAs that rely on domain and DNS names` can be used for `Enterprise/DevOps/DevSecOps/Zero Trust` purposes.
 >
 > **Example:**
 >


### PR DESCRIPTION
- [+] docs(README): add Zero Trust to the list of use cases for Private CAs that rely on domain and DNS names